### PR TITLE
Fixes issue #28

### DIFF
--- a/recipes/blueprints.rb
+++ b/recipes/blueprints.rb
@@ -49,10 +49,18 @@ ambari_server_fqdn =
 
 basic_auth_parameters = "--user #{node['ambari']['admin_user']}:#{node['ambari']['admin_password']}"
 
+file '/tmp/blueprint.json' do
+  content Chef::JSONCompat.to_json_pretty(node['ambari']['blueprints']['blueprint_json'].to_hash)
+end
+
+file '/tmp/cluster.json' do
+  content Chef::JSONCompat.to_json_pretty(node['ambari']['blueprints']['cluster_json'].to_hash)
+end
+
 execute 'Init Blueprints' do
-  command "curl #{basic_auth_parameters} -H 'X-Requested-By:ambari-cookbook' --data '#{node['ambari']['blueprints']['blueprint_json'].to_json}' #{ambari_server_fqdn}:8080/api/v1/blueprints/#{node['ambari']['blueprints']['blueprint_name']}"
+  command "curl #{basic_auth_parameters} -H 'X-Requested-By:ambari-cookbook' --data @/tmp/blueprint.json #{ambari_server_fqdn}:8080/api/v1/blueprints/#{node['ambari']['blueprints']['blueprint_name']}"
 end
 
 execute 'Init Cluster' do
-  command "curl #{basic_auth_parameters} -H 'X-Requested-By:ambari-cookbook' --data '#{node['ambari']['blueprints']['cluster_json'].to_json}' #{ambari_server_fqdn}:8080/api/v1/clusters/#{node['ambari']['blueprints']['cluster_name']}"
+  command "curl #{basic_auth_parameters} -H 'X-Requested-By:ambari-cookbook' --data @/tmp/cluster.json #{ambari_server_fqdn}:8080/api/v1/clusters/#{node['ambari']['blueprints']['cluster_name']}"
 end


### PR DESCRIPTION
Instead of uploading blueprint and cluster definition by submitting json attributes, save to .json files and upload them instead.  

A common approach to deploying hdp environment (and hence use of this cookbook) is to define configuration manually in the webui, export to json, tweak config by editing json (eg add extra cluster nodes) then upload the config.  Unfortunately this often fails because the exported config often contains symbols such as parentheses and quote characters that cause errors such as in issue #28.  Uploading files instead of json text solves.
